### PR TITLE
fix: upgrade to dprint-core 0.69.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasm = ["serde_json", "dprint-core/wasm"]
 
 [dependencies]
 anyhow = "1.0.51"
-dprint-core = { version = "0.67.4", default-features = false }
+dprint-core = { version = "0.69.0", default-features = false }
 serde = { version = "1.0.88", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 sqlformat = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasm = ["serde_json", "dprint-core/wasm"]
 
 [dependencies]
 anyhow = "1.0.51"
-dprint-core = { version = "0.69.0", default-features = false }
+dprint-core = { version = "0.69.1", default-features = false }
 serde = { version = "1.0.88", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 sqlformat = "0.5.0"

--- a/src/wasm_plugin.rs
+++ b/src/wasm_plugin.rs
@@ -5,6 +5,7 @@ use dprint_core::generate_plugin_code;
 use dprint_core::plugins::CheckConfigUpdatesMessage;
 use dprint_core::plugins::ConfigChange;
 use dprint_core::plugins::FileMatchingInfo;
+use dprint_core::plugins::FormatError;
 use dprint_core::plugins::FormatResult;
 use dprint_core::plugins::PluginInfo;
 use dprint_core::plugins::PluginResolveConfigurationResult;
@@ -31,7 +32,7 @@ impl SyncPluginHandler<Configuration> for SqlPluginHandler {
     }
   }
 
-  fn check_config_updates(&self, _message: CheckConfigUpdatesMessage) -> anyhow::Result<Vec<ConfigChange>> {
+  fn check_config_updates(&self, _message: CheckConfigUpdatesMessage) -> Result<Vec<ConfigChange>, FormatError> {
     Ok(Vec::new())
   }
 
@@ -64,7 +65,7 @@ impl SyncPluginHandler<Configuration> for SqlPluginHandler {
     }
 
     let text = String::from_utf8_lossy(&request.file_bytes);
-    let maybe_text = super::format_text(request.file_path, &text, request.config)?;
+    let maybe_text = super::format_text(request.file_path, &text, request.config).map_err(FormatError::new)?;
     Ok(maybe_text.map(|t| t.into_bytes()))
   }
 }


### PR DESCRIPTION
Upgrades `dprint-core` from 0.67.4 to 0.69.0.

## Source changes

Only one source file needed changes, both at the boundary with `dprint-core`'s plugin handler trait, due to the removal of `anyhow` from `dprint-core` in 0.68.0:

- `src/wasm_plugin.rs`
  - `SyncPluginHandler::check_config_updates` now returns `Result<Vec<ConfigChange>, dprint_core::plugins::FormatError>` instead of `anyhow::Result<..>`.
  - `format`'s call to `format_text` now maps the error with `FormatError::new` before `?`, since `?` no longer converts `anyhow::Error` into the core error type.

No changes were needed for the 0.69.0 `GeneratedValue::is_known_multi_line` addition — this plugin delegates to `sqlformat` and does not use `dprint-core`'s IR helpers.

## anyhow

`anyhow` is still a dependency, used only for the return type of the public `format_text` (`anyhow::Result<Option<String>>`). That function is infallible today (it never returns `Err`), so the dependency could be dropped entirely, but doing so would change the crate's public API, so it was left out of this upgrade and can be done separately as a `fix(BREAKING)` change like in the json/markdown/typescript plugins.

## Verification

- `cargo check --all-targets` — clean
- `cargo build --target wasm32-unknown-unknown --features wasm --release` — clean
- `cargo test` — all pass (3 unit + 2 integration tests covering 9 spec files + 2 doctests); no spec expectations changed
- `dprint fmt --excludes "**/*.rs"` — no changes (rustfmt was not run in this environment)
