### PR TITLE
chore: format

### DIFF
--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -96,6 +96,10 @@ async function updateRustToolchain(sqlformatVersion: string) {
     $.log(`Updating Rust toolchain: ${localMatch[1]} -> ${requiredRustVersion}`);
     toolchainPath.writeTextSync(localContent.replace(localMatch[0], `channel = "${requiredRustVersion}"`));
   } else {
-    $.log(`Rust toolchain at ${localMatch[1]} already satisfies sqlformat ${sqlformatVersion} (needs >= ${requiredRustVersion}).`);
+    $.log(
+      `Rust toolchain at ${
+        localMatch[1]
+      } already satisfies sqlformat ${sqlformatVersion} (needs >= ${requiredRustVersion}).`,
+    );
   }
 }


### PR DESCRIPTION
`scripts/update.ts` had a `$.log(...)` line over the line width that `dprint fmt` wants to wrap. Nothing enforces it — this repo's CI has no `dprint check` step — so it went unnoticed.